### PR TITLE
implement POST handling for creating places

### DIFF
--- a/pages/api/places/index.js
+++ b/pages/api/places/index.js
@@ -8,4 +8,17 @@ export default async function handler(request, response) {
     const places = await Place.find();
     return response.status(200).json(places);
   }
+
+  if (request.method === "POST") {
+    try {
+      // const { name, image, location, mapURL, description } = request.body;
+      const placeData = request.body;
+      await Place.create(placeData);
+
+      response.status(201).json({ status: "Place created" });
+    } catch (error) {
+      console.error("Error creating place:", error);
+      response.status(400).json({ error: error.message });
+    }
+  }
 }

--- a/pages/create.js
+++ b/pages/create.js
@@ -11,8 +11,24 @@ const StyledBackLink = styled(StyledLink)`
 export default function CreatePlacePage() {
   const router = useRouter();
 
-  function addPlace(place) {
-    console.log("Place added (but not really...)");
+  async function addPlace(place) {
+    try {
+      const response = await fetch("/api/places", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(place),
+      });
+
+      if (response.ok) {
+        router.push("/");
+      } else {
+        console.error("Error submitting Place");
+      }
+    } catch (error) {
+      console.error("Error submitting Place:", error);
+    }
   }
 
   return (


### PR DESCRIPTION
Enhance the API route in `pages/api/places/index.js` to handle `POST` requests for creating new places. The `addPlace` function in `pages/create.js` now performs a `POST` request to the API endpoint when submitting the form, allowing users to create new places.