### PR TITLE
implement delete functionality for place entries

### DIFF
--- a/pages/api/places/[id]/index.js
+++ b/pages/api/places/[id]/index.js
@@ -27,4 +27,18 @@ export default async function handler(request, response) {
       return response.status(400).json({ error: error.message });
     }
   }
+  if (request.method === "DELETE") {
+    try {
+      const deletedPlace = await Place.findByIdAndDelete(id);
+
+      if (!deletedPlace) {
+        return response.status(404).json({ error: "Place not found" });
+      }
+
+      return response.status(200).json({ message: "Place deleted" });
+    } catch (error) {
+      console.error("Error deleting place:", error);
+      return response.status(500).json({ error: "Internal Server Error" });
+    }
+  }
 }

--- a/pages/places/[id]/index.js
+++ b/pages/places/[id]/index.js
@@ -37,8 +37,20 @@ export default function DetailsPage() {
 
   if (!isReady || isLoading || error) return <h2>Loading...</h2>;
 
-  function deletePlace() {
-    console.log("deleted?");
+  async function deletePlace() {
+    try {
+      const response = await fetch(`/api/places/${id}`, {
+        method: "DELETE",
+      });
+
+      if (response.ok) {
+        router.push("/");
+      } else {
+        console.error("Error deleting place");
+      }
+    } catch (error) {
+      console.error("Error deleting place:", error);
+    }
   }
 
   return (


### PR DESCRIPTION
Enhance the API route in `pages/api/places/[id]/index.js` to handle `DELETE` requests for deleting specific place entries. The `deletePlace` function in `pages/places/[id]/index.js` now performs a `DELETE` request to the API endpoint when the user clicks the "Delete" button on a place's details page.